### PR TITLE
Maintain enum order for select options

### DIFF
--- a/src/directives/decorators/bootstrap/select.html
+++ b/src/directives/decorators/bootstrap/select.html
@@ -7,7 +7,7 @@
           class="form-control"
           schema-validate="form.schema"
           ng-required="form.required"
-          ng-options="val as name for (val,name) in form.titleMap">
+          ng-options="val as form.titleMap[val] for val in form.schema.enum">
   </select>
   <span class="help-block">{{ (hasError() && errorMessage(schemaError())) || form.description}} </span>
 </div>


### PR DESCRIPTION
Maintains the original sort order of an `enum` for `string` types which result in the `select.html` template.

Using an `orderBy` filter is another option, but I think this is more readable.
