### PR TITLE
Claerfix typo

### DIFF
--- a/src/directives/decorators/bootstrap/tabarray.html
+++ b/src/directives/decorators/bootstrap/tabarray.html
@@ -21,7 +21,7 @@
 
   <div ng-class="{'col-xs-9': !form.tabsType || form.tabsType === 'left' || form.tabsType === 'right'}">
     <div class="tab-content">
-      <div class="tab-pane claerfix"
+      <div class="tab-pane clearfix"
            ng-repeat="item in modelArray track by $index"
            ng-show="selected.tab === $index"
            ng-class="{active: selected.tab === $index}">


### PR DESCRIPTION
The typo doesn´t break the examples. I fount it as working on another feature
