### PR TITLE
added hook for custom validation callback per form field

### DIFF
--- a/src/directives/schema-validate.js
+++ b/src/directives/schema-validate.js
@@ -43,6 +43,19 @@ angular.module('schemaForm').directive('schemaValidate',function(){
         }
 
         var result = tv4.validateResult(value,schema);
+
+        if (result.valid) {
+          // check for validation callbacks
+          var form = scope.$eval(attrs.sfChanged);
+          if (form && form.validationCallback) {
+            if (angular.isFunction(form.validationCallback)) {
+              result = form.validationCallback(value, form);
+            } else {
+              result = scope.evalExpr(form.validationCallback, {'modelValue': value, form: form});
+            }
+          }
+        }
+
         if (result.valid) {
           // it is valid
           ngModel.$setValidity('schema', true);


### PR DESCRIPTION
I needed a hook for a custom validation function.
I could not find this feature in the project, hope I didn't miss it.

Now you can have the property `validationCallback: "someCallBack(modelValue, form)"` on your form field.
This callback should return an object with properties `valid (boolean)` and `error (error code)`.
This will only be called, if the tv4 schema validation was successful.
