### PR TITLE
Made bootstrap-vertical-tabs a dev dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,10 +26,10 @@
     "angular": "~1.2.18",
     "tv4": "~1.0.15",
     "pickadate": "~3.5.2",
-    "angular-sanitize": "~1.2.18",
-    "bootstrap-vertical-tabs": "~1.1.0"
+    "angular-sanitize": "~1.2.18"
   },
   "devDependencies": {
-    "angular-ui-ace": "bower"
+    "angular-ui-ace": "bower",
+    "bootstrap-vertical-tabs": "~1.1.0"
   }
 }


### PR DESCRIPTION
According to the readme, bootstrap-vertical-tabs is only needed if you want vertical tabs, but it's included in the dependencies of the project. Unfortunately, bootstrap-vertical-tabs has a dependency on bootstrap itself, which means that the whole of bootstrap gets pulled in if you want to use angular-schema-form.

I think there are two problems with this:
1. What if you're not using bootstrap? You have to include a huge dependency that you don't want
2. What if you are using bootstrap, but you're using a non-standard version? (I'm using bootstrap-sass for example) You end up with two versions of bootstrap, potentially conflicting with each other.

I believe that anyone who still wants to use vertical tabs can manually add it as a dependency and it will still work for them.
