### PR TITLE
fixed default setting of boolean fields with default false

### DIFF
--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -25,7 +25,7 @@ angular.module('schemaForm').provider('schemaForm',[function(){
     if (schema.title) f.title = schema.title;
     if (schema.description) f.description = schema.description;
     if (options.required === true || schema.required === true) f.required = true;
-    if (schema.default) f.default = schema.default;
+    if (schema.default !== undefined) f.default = schema.default;
     if (schema.maxLength) f.maxlength = schema.maxLength;
     if (schema.minLength) f.minlength = schema.maxLength;
     if (schema.readOnly || schema.readonly)  f.readonly  = schema.readOnly || schema.readonly;

--- a/test/schema-form-test.js
+++ b/test/schema-form-test.js
@@ -1634,6 +1634,11 @@ describe('Schema form',function(){
                 "NaN",
               ]
             },
+            "overEighteen": {
+              "title": "Are you over 18 years old?",
+              "type": "boolean",
+              "default": false
+            },
             "attributes": {
               "type": "object",
               "required": ['eyecolor'],
@@ -1682,6 +1687,17 @@ describe('Schema form',function(){
                 "null",
                 "NaN",
               ]
+            }
+          },
+          {
+            title: 'Are you over 18 years old?',
+            key: 'overEighteen',
+            type: 'checkbox',
+            default: false,
+            schema: {
+              "title": "Are you over 18 years old?",
+              "type": "boolean",
+              "default": false
             }
           },
           {


### PR DESCRIPTION
When you assign `false` to a boolean field in the schema, this was not copied to the form/model.
