### PR TITLE
Remove bootstrap-datepicker from bower.json "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,7 @@
   "name": "angular-schema-form",
   "main": [
     "dist/schema-form.min.js",
-    "dist/bootstrap-decorator.min.js",
-    "dist/bootstrap-datepicker.min.js"
+    "dist/bootstrap-decorator.min.js"
   ],
   "version": "0.7.3",
   "authors": [


### PR DESCRIPTION
Removed reference to bootstrap-datepicker from bower.json to reflect its separation from this repo. (Its presence is breaking the dependency concatenation stage of a dependent project's build.)
