### PR TITLE
Fixed ui-sortable bower dependency that was ambiguous

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "jquery": "~2.1.1",
     "angular-mocks": ">= 1.2",
     "tx-tinymce": ">= 0.0.5",
-    "angular-ui-sortable": "~0.12.11",
+    "angular-ui-sortable": ">=0.12.11",
     "bootstrap-vertical-tabs": "~1.2.0"
   }
 }


### PR DESCRIPTION
Should sort the bower issue, and in turn the errors that travis is throwing. Thanks to @Sandreu for fixing it in his  PR, just doing it for a release.
