### PR TITLE
Use objectpath more generically to fix requirejs issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "angular": ">= 1.2",
     "tv4": "~1.0.15",
     "angular-sanitize": ">= 1.2",
-    "objectpath": "~1.0.4"
+    "objectpath": "~1.1.0"
   },
   "devDependencies": {
     "angular-ui-ace": "bower",

--- a/src/module.js
+++ b/src/module.js
@@ -1,7 +1,7 @@
 // Deps is sort of a problem for us, maybe in the future we will ask the user to depend
 // on modules for add-ons
 
-var deps = ['ObjectPath'];
+var deps = [];
 try {
   //This throws an expection if module does not exist.
   angular.module('ngSanitize');

--- a/src/sfPath.js
+++ b/src/sfPath.js
@@ -1,26 +1,28 @@
 angular.module('schemaForm').provider('sfPath',
-['ObjectPathProvider', function(ObjectPathProvider) {
-  var ObjectPath = {parse: ObjectPathProvider.parse};
+[function() {
+  var sfPath = {parse: ObjectPath.parse};
 
   // if we're on Angular 1.2.x, we need to continue using dot notation
   if (angular.version.major === 1 && angular.version.minor < 3) {
-    ObjectPath.stringify = function(arr) {
+    sfPath.stringify = function(arr) {
       return Array.isArray(arr) ? arr.join('.') : arr.toString();
     };
   } else {
-    ObjectPath.stringify = ObjectPathProvider.stringify;
+    sfPath.stringify = ObjectPath.stringify;
   }
 
   // We want this to use whichever stringify method is defined above,
   // so we have to copy the code here.
-  ObjectPath.normalize = function(data, quote) {
-    return ObjectPath.stringify(Array.isArray(data) ? data : ObjectPath.parse(data), quote);
+  sfPath.normalize = function(data, quote) {
+    return sfPath.stringify(Array.isArray(data) ? data : sfPath.parse(data), quote);
   };
 
-  this.parse = ObjectPath.parse;
-  this.stringify = ObjectPath.stringify;
-  this.normalize = ObjectPath.normalize;
+  // expose the methods in sfPathProvider
+  this.parse = sfPath.parse;
+  this.stringify = sfPath.stringify;
+  this.normalize = sfPath.normalize;
+
   this.$get = function() {
-    return ObjectPath;
+    return sfPath;
   };
 }]);


### PR DESCRIPTION
It looks like the ObjectPath dependency was breaking angular-schema-form installs in environments that use require.js (see https://github.com/mike-marcacci/objectpath/issues/1), because ObjectPath couldn't automatically register itself with angular. I've removed the auto-registration in a new version of ObjectPath, and this PR fixes the issue accordingly.

I don't use either AMD or require.js in my schema-form projects, so maybe @frhd or @skchrko can check this out?

Please note that this requires users to upgrade ObjectPath to 1.1 when they upgrade ASF (assuming they aren't using bower).
