### PR TITLE
Fire event, when rendering of form is ready

### DIFF
--- a/src/directives/schema-form.js
+++ b/src/directives/schema-form.js
@@ -117,7 +117,7 @@ angular.module('schemaForm')
               }
             });
           };
-          $(element[0]).triggerHandler("sf-render-finished");
+          scope.$emit("sf-render-finished");
         });
       }
     };


### PR DESCRIPTION
With this event, we can do some extra things to the rendered form. My use case is executing $.material.init() from https://github.com/FezVrasta/bootstrap-material-design. I can not do that with postprocess, because I need a fully rendered form in my use case.
