### PR TITLE
fieldId()'s for names and ids

### DIFF
--- a/src/directives/field.js
+++ b/src/directives/field.js
@@ -9,9 +9,12 @@ angular.module('schemaForm').directive('sfField',
         replace: false,
         transclude: false,
         scope: true,
-        require: '^sfSchema',
+        require: ['^sfSchema', '?^form'],
         link: {
-          pre: function(scope, element, attrs, sfSchema) {
+          pre: function(scope, element, attrs, Ctrl) {
+            var sfSchema = Ctrl[0];
+            var formCtrl = Ctrl[1];
+
             //The ngModelController is used in some templates and
             //is needed for error messages,
             scope.$on('schemaFormPropagateNgModelController', function(event, ngModel) {
@@ -23,7 +26,10 @@ angular.module('schemaForm').directive('sfField',
             // Fetch our form.
             scope.form = sfSchema.lookup['f' + attrs.sfField];
           },
-          post: function(scope, element, attrs, sfSchema) {
+          post: function(scope, element, attrs, Ctrl) {
+            var sfSchema = Ctrl[0];
+            var formCtrl = Ctrl[1];
+            
             //Keep error prone logic from the template
             scope.showTitle = function() {
               return scope.form && scope.form.notitle !== true && scope.form.title;
@@ -153,6 +159,23 @@ angular.module('schemaForm').directive('sfField',
                 scope.options && scope.options.validationMessage
               );
             };
+
+            scope.fieldId = function(prependFormName, omitNumbers) {
+              if(scope.form.key){
+                var fieldKey = scope.form.key;
+                if(omitNumbers){
+                  fieldKey = fieldKey.filter(function(key){
+                    return !angular.isNumber(key);
+                  });
+                }
+                return ((prependFormName && formCtrl && formCtrl.$name)?formCtrl.$name+'-':'')+fieldKey.join('-');
+              }
+              return '';
+            };
+
+            // append the field-id to the htmlClass
+            if(!scope.form.htmlClass){ scope.form.htmlClass = ''; }
+            scope.form.htmlClass += (scope.form.htmlClass?' ':'')+scope.fieldId(false, true);
 
             var form = scope.form;
 

--- a/src/services/decorators.js
+++ b/src/services/decorators.js
@@ -39,8 +39,10 @@ angular.module('schemaForm').provider('schemaFormDecorators',
           replace: false,
           transclude: false,
           scope: true,
-          require: '?^sfSchema',
-          link: function(scope, element, attrs, sfSchema) {
+          require: ['?^sfSchema', '?^form'],
+          link: function(scope, element, attrs, Ctrl) {
+            var sfSchema = Ctrl[0];
+            var formCtrl = Ctrl[1];
 
             //The ngModelController is used in some templates and
             //is needed for error messages,
@@ -149,6 +151,19 @@ angular.module('schemaForm').provider('schemaFormDecorators',
               return scope.ngModel.$invalid && !scope.ngModel.$pristine;
             };
 
+            scope.fieldId = function(prependFormName, omitNumbers) {
+              if(scope.form.key){
+                var fieldKey = scope.form.key;
+                if(omitNumbers){
+                  fieldKey = fieldKey.filter(function(key){
+                    return !angular.isNumber(key);
+                  });
+                }
+                return ((prependFormName && formCtrl && formCtrl.$name)?formCtrl.$name+'-':'')+fieldKey.join('-');
+              }
+              return '';
+            };
+
             /**
              * DEPRECATED: use sf-messages instead.
              * Error message handler
@@ -173,6 +188,10 @@ angular.module('schemaForm').provider('schemaFormDecorators',
                 // and https://github.com/Textalk/angular-schema-form/issues/206
                 form.ngModelOptions = form.ngModelOptions || {};
                 scope.form  = form;
+
+                // append the field-id to the htmlClass
+                if(!scope.form.htmlClass){ scope.form.htmlClass = ''; }
+                scope.form.htmlClass += (scope.form.htmlClass?' ':'')+scope.fieldId(false, true);
 
                 //ok let's replace that template!
                 //We do this manually since we need to bind ng-model properly and also


### PR DESCRIPTION
decorators should be updated (typically) by:
replacing:
`form.key.slice(-1)[0]`
with:
`fieldId()` in name attributes
`fieldId(true)` in id/for/aria-describedby attributes
