### PR TITLE
Revalidate model after successful custom validation event broadcasted

### DIFF
--- a/src/directives/field.js
+++ b/src/directives/field.js
@@ -188,6 +188,9 @@ angular.module('schemaForm').directive('sfField',
                     scope.ngModel.$setValidity(error, validity === true);
 
                     if (validity === true) {
+                      // Re-trigger model validator, that model itself would be re-validated
+                      scope.ngModel.$validate();
+
                       // Setting or removing a validity can change the field to believe its valid
                       // but its not. So lets trigger its validation as well.
                       scope.$broadcast('schemaFormValidate');

--- a/src/services/decorators.js
+++ b/src/services/decorators.js
@@ -256,6 +256,9 @@ angular.module('schemaForm').provider('schemaFormDecorators',
                         scope.ngModel.$setValidity(error, validity === true);
 
                         if (validity === true) {
+                          // Re-trigger model validator, that model itself would be re-validated
+                          scope.ngModel.$validate();
+
                           // Setting or removing a validity can change the field to believe its valid
                           // but its not. So lets trigger its validation as well.
                           scope.$broadcast('schemaFormValidate');


### PR DESCRIPTION
# Description

Custom validation of input fails if event of successful validation is broadcasted after input validation is executed in onChange method (for example custom validation takes some time - timeout, async request etc.).   

## Reproduce

Enter "yzy" as name, wait a second till custom validation with timeout will ran (you will get "exists" error message). Enter one more character wait one more second. Input will be marked as invalid although it is valid.

https://jsfiddle.net/t1a8nhop/

## Fix relates with issues
#577
#637
#440