### PR TITLE
set firstDigest to false in schemaValidate directive

### DIFF
--- a/src/directives/newArray.js
+++ b/src/directives/newArray.js
@@ -20,6 +20,7 @@ function(sel, sfPath, schemaForm) {
         // validateField method is exported by schema-validate
         if (scope.ngModel && scope.ngModel.$pristine && scope.firstDigest &&
             (!scope.options || scope.options.validateOnRender !== true)) {
+          scope.firstDigest = false;
           return;
         } else if (scope.validateField) {
           scope.validateField();

--- a/src/directives/schema-form.js
+++ b/src/directives/schema-form.js
@@ -123,10 +123,6 @@ angular.module('schemaForm')
           // I.e. just rendered the form so we know not to validate
           // empty fields.
           childScope.firstDigest = true;
-          // We use a ordinary timeout since we don't need a digest after this.
-          setTimeout(function() {
-            childScope.firstDigest = false;
-          }, 0);
 
           //compile only children
           $compile(element.children())(childScope);

--- a/src/directives/schema-validate.js
+++ b/src/directives/schema-validate.js
@@ -146,6 +146,7 @@ angular.module('schemaForm').directive('schemaValidate', ['sfValidator', '$parse
           // we usually don't want that.
           if (ngModel.$pristine  && scope.firstDigest &&
               (!scope.options || scope.options.validateOnRender !== true))  {
+            scope.firstDigest = false;
             return val;
           }
           validate(ngModel.$modelValue);


### PR DESCRIPTION
In my specific use case, I have a customized multi-select form element. But when the form is first loaded, `scope.firstDigest` of this directive is `false`. AT: [schema-form.js#L2858](https://github.com/json-schema-form/angular-schema-form/blob/development/dist/schema-form.js#L2858)

Which makes it to validate this form element, and update `ngModel.$error` at the first time. This is not the expected behavior I think. `scope.firstDigest` here should be true the first time it is loaded.

I could solve the issue by increasing the timeout at [schema-form.js#L2634](https://github.com/json-schema-form/angular-schema-form/blob/development/dist/schema-form.js#L2634) to for example: `1000`. So, I guess this may related to the sequence how angular initialize the directives and how much time each directive will take.

This pull request do solved my issue, but I'm not sure if there are more elegant ways(or if this breaks anything). feel free to comment :)
