### PR TITLE
Fix for #121 to redraw with proper defaults

### DIFF
--- a/src/directives/schema-form.js
+++ b/src/directives/schema-form.js
@@ -170,7 +170,7 @@ angular.module('schemaForm')
         // part of the form or schema is chnaged without it being a new instance.
         scope.$on('schemaFormRedraw', function() {
           var schema = scope.schema;
-          var form   = scope.initialForm || ['*'];
+          var form   = scope.initialForm ? angular.copy(scope.initialForm) : ['*'];
           if (schema) {
             render(schema, form);
           }

--- a/test/directives/schema-form-test.js
+++ b/test/directives/schema-form-test.js
@@ -1768,6 +1768,59 @@ describe('directive',function(){
     });
   });
 
+  it('should redraw form with proper defaults on schemaFormRedraw event',function(done) {
+
+    inject(function($compile, $rootScope){
+      var scope = $rootScope.$new();
+      scope.person = {};
+
+      scope.schema = {
+        type: 'object',
+        properties: {
+          name: {type: 'string'}
+        }
+      };
+
+      scope.form = [{
+        key: 'name',
+        type: 'text'
+      }];
+
+      scope.options = {formDefaults: {}};
+
+      var tmpl = angular.element('<form sf-schema="schema" sf-form="form" sf-model="person" sf-options="options"></form>');
+
+      $compile(tmpl)(scope);
+      $rootScope.$apply();
+
+      expect(tmpl.find('input').attr('disabled')).to.be.undefined;
+
+      var disable, enable;
+      disable = function () {
+        // form element should be disabled
+        scope.options.formDefaults.readonly = true;
+        scope.$broadcast('schemaFormRedraw');
+        $rootScope.$apply();
+        expect(tmpl.find('input').attr('disabled')).eq('disabled');
+
+        // try to re-enable it by modifying global option
+        setTimeout(enable, 0);
+      };
+
+      enable = function () {
+        // form element should be back to enabled
+        scope.options.formDefaults.readonly = false;
+        scope.$broadcast('schemaFormRedraw');
+        $rootScope.$apply();
+        expect(tmpl.find('input').attr('disabled')).to.be.undefined;
+
+        done();
+      }
+
+      setTimeout(disable, 0);
+    });
+  });
+
   it('should use supplied template with template field type',function() {
 
     inject(function($compile, $rootScope){


### PR DESCRIPTION
The problem was that initialForm was used to generate a form on redraw
event, but when it was an object type, it was modified in-place by
rendering function. So, when the next redraw event happened, initialForm
already had the properties defined, and it prevented the default values
from being populated into them.