### PR TITLE
arrayIndices to allow conditions to access the array index in nested arrays

### DIFF
--- a/src/directives/field.js
+++ b/src/directives/field.js
@@ -48,14 +48,23 @@ angular.module('schemaForm').directive('sfField',
             };
 
             scope.buttonClick = function($event, form) {
+              var arrayDepth = form.key.filter(function(e) { return e === '' }).length;
+              var arrayIndices = (arrayDepth > 1 ? Array(arrayDepth - 1).join('$parent.$parent.$parent.') + '$parent.$parent.$index,' : '');
+              for (var i = arrayDepth; i > 2; i--) {
+                  arrayIndices += Array(i - 1).join('$parent.$parent.$parent.') + '$index,';
+              }
+              arrayIndices += '$index';
+              arrayIndices = scope.$eval('[' + arrayIndices + ']');
+              
               if (angular.isFunction(form.onClick)) {
-                form.onClick($event, form);
+                
+                form.onClick($event, form, arrayIndices[arrayDepth-1], arrayIndices);
               } else if (angular.isString(form.onClick)) {
                 if (sfSchema) {
                   //evaluating in scope outside of sfSchemas isolated scope
-                  sfSchema.evalInParentScope(form.onClick, {'$event': $event, form: form});
+                  sfSchema.evalInParentScope(form.onClick, {'$event': $event, form: form, arrayIndex: arrayIndices[arrayDepth-1], arrayIndices: arrayIndices});
                 } else {
-                  scope.$eval(form.onClick, {'$event': $event, form: form});
+                  scope.$eval(form.onClick, {'$event': $event, form: form, arrayIndex: '$index', arrayIndices: '[' + arrayIndices + ']'});
                 }
               }
             };

--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -114,7 +114,7 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
           var arrayDepth = args.form.key.filter(function(e) { return e === '' }).length;
           var arrayIndices = '$index';
           for (var i = 1; i < arrayDepth; i++) {
-            arrayIndices = Array(i + 1).join('$parent.') + '$index,' + arrayIndices;
+            arrayIndices = Array(i + 1).join('$parent.$parent.') + '$index,' + arrayIndices;
           }
 
           evalExpr = 'evalExpr(' + args.path + '.condition,{ model: model, "arrayIndex": $index, ' +

--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -111,7 +111,7 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
                        '.condition, { model: model, "arrayIndex": $index})';
         if (args.form.key) {
           var strKey = sfPathProvider.stringify(args.form.key);
-          var arrayDepth = (args.path.split('.items[').length - 1);
+          var arrayDepth = args.form.key.filter(function(e) { return e === '' }).length;
           var arrayIndices = '$index';
           for (var i = 1; i < arrayDepth; i++) {
             arrayIndices = Array(i + 1).join('$parent.') + '$index,' + arrayIndices;

--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -111,7 +111,14 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
                        '.condition, { model: model, "arrayIndex": $index})';
         if (args.form.key) {
           var strKey = sfPathProvider.stringify(args.form.key);
+          var arrayDepth = (args.path.split('.items[').length - 1);
+          var arrayIndices = '$index';
+          for (var i = 1; i < arrayDepth; i++) {
+            arrayIndices = Array(i + 1).join('$parent.') + '$index,' + arrayIndices;
+          }
+
           evalExpr = 'evalExpr(' + args.path + '.condition,{ model: model, "arrayIndex": $index, ' +
+                     '"arrayIndices": [' + arrayIndices + '],' +
                      '"modelValue": model' + (strKey[0] === '[' ? '' : '.') + strKey + '})';
         }
 

--- a/src/services/decorators.js
+++ b/src/services/decorators.js
@@ -207,7 +207,7 @@ angular.module('schemaForm').provider('schemaFormDecorators',
 
                     var evalExpr = 'evalExpr(form.condition,{ model: model, "arrayIndex": arrayIndex})';
                     if (form.key) {
-                      evalExpr = 'evalExpr(form.condition,{ model: model, "arrayIndex": arrayIndex, "modelValue": model' + sfPath.stringify(form.key) + '})';
+                      evalExpr = 'evalExpr(form.condition,{ model: model, "arrayIndex": arrayIndex, "arrayIndices": [' + form.key.filter(function(e) { return e === parseInt(e, 10)}).toString() + '], "modelValue": model' + sfPath.stringify(form.key) + '})';
                     }
 
                     angular.forEach(element.children(), function(child) {

--- a/src/services/decorators.js
+++ b/src/services/decorators.js
@@ -74,14 +74,16 @@ angular.module('schemaForm').provider('schemaFormDecorators',
             };
 
             scope.buttonClick = function($event, form) {
+              var arrayIndices = form.key.filter(function(e) { return e === parseInt(e, 10)});
+              
               if (angular.isFunction(form.onClick)) {
-                form.onClick($event, form);
+                form.onClick($event, form, arrayIndices[arrayIndices.length-1], arrayIndices);
               } else if (angular.isString(form.onClick)) {
                 if (sfSchema) {
                   //evaluating in scope outside of sfSchemas isolated scope
-                  sfSchema.evalInParentScope(form.onClick, {'$event': $event, form: form});
+                  sfSchema.evalInParentScope(form.onClick, {'$event': $event, form: form, arrayIndex: arrayIndices[arrayIndices.length-1], arrayIndices: arrayIndices});
                 } else {
-                  scope.$eval(form.onClick, {'$event': $event, form: form});
+                  scope.$eval(form.onClick, {'$event': $event, form: form, arrayIndex: arrayIndices[arrayIndices.length-1], arrayIndices: arrayIndices});
                 }
               }
             };

--- a/test/directives/schema-form-test.js
+++ b/test/directives/schema-form-test.js
@@ -2564,7 +2564,17 @@ describe('directive',function(){
                         "ownerName": ""
                       },
                       {
-                        "ownerName": "Ben"
+                        "ownerName": "Arlo",
+                        "logBookProvided": "yes",
+                        "logBookEntry": [
+                          {
+                            "entryId": 2,
+                            "entryDate": "2015-06-23"
+                          },
+                          {
+                            "entryId": 4
+                          }
+                        ]
                       }
                     ]
                   }
@@ -2625,7 +2635,18 @@ describe('directive',function(){
                                 properties: {
                                   ownerName: { type: "string" },
                                   purchaseDate: { type: "string" },
-                                  logBookProvided: { type: "string", enum: ["yes", "no"] }
+                                  logBookProvided: { type: "string", enum: ["yes", "no"] },
+                                  logBookEntry: {
+                                    type: "array",
+                                    items: {
+                                      type: "object",
+                                      properties: {
+                                        entryId: { type: "number" },
+                                        entryDate: { type: "string" },
+                                        entryNote: { type: "string" }
+                                      }
+                                    } 
+                                  }
                                 }
                               }
                             }
@@ -2671,7 +2692,19 @@ describe('directive',function(){
                       {
                         key: "transportCategory[].transportOption[].history.previousOwners[].logBookProvided",
                         condition: "model.transportCategory[arrayIndices[0]].mode != 'Horse' && model.transportCategory[arrayIndices[0]].transportOption[arrayIndices[1]].history.previousOwners[arrayIndices[2]].ownerName.length > 2"
-                      }
+                      },
+                      {
+                        key: "transportCategory[].transportOption[].history.previousOwners[].logBookEntry",
+                        condition: "model.transportCategory[arrayIndices[0]].transportOption[arrayIndices[1]].history.previousOwners[arrayIndices[2]].logBookProvided == 'yes'",
+                        items: [
+                          "transportCategory[].transportOption[].history.previousOwners[].logBookEntry[].entryId",
+                          "transportCategory[].transportOption[].history.previousOwners[].logBookEntry[].entryDate",
+                          {
+                            key: "transportCategory[].transportOption[].history.previousOwners[].logBookEntry[].entryNote",
+                            condition: "model.transportCategory[arrayIndices[0]].transportOption[arrayIndices[1]].history.previousOwners[arrayIndices[2]].logBookEntry[arrayIndices[3]].entryDate.length > 2"
+                          }
+                        ]
+                      } 
                     ]
                   }
                 ]
@@ -2710,10 +2743,15 @@ describe('directive',function(){
 
         renderedForm.transportCategory[0].transportOption[1]['history'] = {
           previousOwners: [
-            renderedForm.transportCategory[0].transportOption[1].node.children().eq(5).children().eq(0),
-            renderedForm.transportCategory[0].transportOption[1].node.children().eq(5).children().eq(1)
+            { node: renderedForm.transportCategory[0].transportOption[1].node.children().eq(5).children().eq(0) },
+            { node: renderedForm.transportCategory[0].transportOption[1].node.children().eq(5).children().eq(1) }
           ]
         };
+        
+        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1]['logBookEntry'] = [
+          { node: renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].node.children().eq(1).children().eq(4).children().eq(1).children().eq(0) },
+          { node: renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].node.children().eq(1).children().eq(4).children().eq(1).children().eq(1) }
+        ];
 
         /*** transportCategory[].transportOption[].numberOfWheels condition tests ***/
         renderedForm.transportCategory[0].node.find('input[name="numberOfWheels"]').length.should.be.eq(2);
@@ -2739,8 +2777,8 @@ describe('directive',function(){
         /*** transportCategory[].transportOption[].history.previousOwners[].purchaseDate field condition tests ***/
         renderedForm.transportCategory[0].transportOption[0].node.find('input[name="purchaseDate"]').length.should.be.eq(0);
         renderedForm.transportCategory[0].transportOption[1].node.find('input[name="purchaseDate"]').length.should.be.eq(1);
-        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[0].find('input[name="purchaseDate"]').length.should.be.eq(0);
-        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].find('input[name="purchaseDate"]').length.should.be.eq(1);
+        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[0].node.find('input[name="purchaseDate"]').length.should.be.eq(0);
+        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].node.find('input[name="purchaseDate"]').length.should.be.eq(1);
 
         renderedForm.transportCategory[1].transportOption[0].node.find('input[name="purchaseDate"]').length.should.be.eq(0);
         renderedForm.transportCategory[1].transportOption[1].node.find('input[name="purchaseDate"]').length.should.be.eq(1);
@@ -2748,12 +2786,16 @@ describe('directive',function(){
         /*** transportCategory[].transportOption[].history.previousOwners[].logBookProvided field condition tests ***/
         renderedForm.transportCategory[0].transportOption[0].node.find('select[name="logBookProvided"]').length.should.be.eq(0);
         renderedForm.transportCategory[0].transportOption[1].node.find('select[name="logBookProvided"]').length.should.be.eq(1);
-        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[0].find('select[name="logBookProvided"]').length.should.be.eq(0);
-        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].find('select[name="logBookProvided"]').length.should.be.eq(1);
+        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[0].node.find('select[name="logBookProvided"]').length.should.be.eq(0);
+        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].node.find('select[name="logBookProvided"]').length.should.be.eq(1);
 
         renderedForm.transportCategory[1].transportOption[0].node.find('select[name="logBookProvided"]').length.should.be.eq(0);
         renderedForm.transportCategory[1].transportOption[1].node.find('select[name="logBookProvided"]').length.should.be.eq(0);
 
+        /*** transportCategory[].transportOption[].history.previousOwners[].logBookEntry[].entryNote  field condition tests ***/
+        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].logBookEntry[0].node.find('input[name="entryNote"]').length.should.be.eq(1);
+        renderedForm.transportCategory[0].transportOption[1].history.previousOwners[1].logBookEntry[1].node.find('input[name="entryNote"]').length.should.be.eq(0);
+        
         done();
       });
     });

--- a/test/directives/schema-form-test.js
+++ b/test/directives/schema-form-test.js
@@ -2537,6 +2537,126 @@ describe('directive',function(){
     });
 
 
+    it('should remove or add fields in an array depending on conditions using arrayIndices', function (done) {
+
+      inject(function ($compile, $rootScope) {
+        var scope = $rootScope.$new();
+        scope.model = {
+          "transportCategory": [
+            {
+              "mode": "Car",
+              "transportOption": [
+                {
+                  "name": "Bertie",
+                  "forSale": "yes",
+                  "price": 100
+                },
+                {
+                  "name": "Lightning McQueen",
+                  "forSale": "no"
+                }
+              ]
+            },
+            {
+              "mode": "Horse",
+              "transportOption": [
+                {
+                  "name": "Phar Lap",
+                  "forSale": "no"
+                },
+                {
+                  "name": "Greyhound",
+                  "forSale": "yes",
+                  "price": 1000
+                }
+              ]
+            }
+          ]
+        };
+
+        scope.schema = {
+          type: "object",
+          properties: {
+            transportCategory: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  mode: { type: "string", enum: ["Car", "Motorbike", "Horse"] },
+                  transportOption: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        name: { type: "string" },
+                        numberOfWheels: { type: "number" },
+                        forSale: { type: "string", enum: ["yes", "no"] },
+                        price: { type: "number" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        scope.form = [
+          {
+            key: "transportCategory",
+            items: [
+              "transportCategory[].mode",
+              {
+                key: "transportCategory[].transportOption",
+                items: [
+                  "transportCategory[].transportOption[].name",
+                  {
+                    key: "transportCategory[].transportOption[].numberOfWheels",
+                    condition: "model.transportCategory[arrayIndices[0]].mode != 'Horse'"
+                  },
+                  "transportCategory[].transportOption[].forSale",
+                  {
+                    key: "transportCategory[].transportOption[].price",
+                    condition: "model.transportCategory[arrayIndices[0]].transportOption[arrayIndices[1]].forSale == 'yes'"
+                  }
+                ]
+              }
+            ]
+          }
+        ];
+
+        var tmpl = angular.element('<form sf-schema="schema" sf-form="form" sf-model="model"></form>');
+
+        $compile(tmpl)(scope);
+        $rootScope.$apply();
+
+        /*** numberOfWheels condition tests ***/
+        tmpl.children().eq(0).children().eq(1).children().eq(0).find('input[name="numberOfWheels"]').length.should.be.eq(2);
+        tmpl.children().eq(0).children().eq(1).children().eq(1).find('input[name="numberOfWheels"]').length.should.be.eq(0);
+        //numberOfWheels [0][0]
+        tmpl.children().eq(0).children().eq(1).children().eq(0).children().eq(2).children().eq(1).children().eq(0).children().eq(2).children().eq(0).text().should.be.equal('numberOfWheels');
+        //numberOfWheels [0][1]
+        tmpl.children().eq(0).children().eq(1).children().eq(0).children().eq(2).children().eq(1).children().eq(1).children().eq(2).children().eq(0).text().should.be.equal('numberOfWheels');
+        //numberOfWheels [1][0]
+        tmpl.children().eq(0).children().eq(1).children().eq(1).children().eq(2).children().eq(1).children().eq(0).children().eq(2).children().eq(0).text().should.be.equal('forSale');
+        //numberOfWheels [1][1]
+        tmpl.children().eq(0).children().eq(1).children().eq(1).children().eq(2).children().eq(1).children().eq(1).children().eq(2).children().eq(0).text().should.be.equal('forSale');
+
+        /*** price field condition tests ***/
+        tmpl.children().eq(0).children().eq(1).children().find('input[name="price"]').length.should.be.eq(2);
+
+        //price [0][0]
+        tmpl.children().eq(0).children().eq(1).children().eq(0).children().eq(2).children().eq(1).children().eq(0).find('input[name="price"]').length.should.be.eq(1);
+        //price [0][1]
+        tmpl.children().eq(0).children().eq(1).children().eq(0).children().eq(2).children().eq(1).children().eq(1).find('input[name="price"]').length.should.be.eq(0);
+        //price [1][0]
+        tmpl.children().eq(0).children().eq(1).children().eq(1).children().eq(2).children().eq(1).children().eq(0).find('input[name="price"]').length.should.be.eq(0);
+        //price [1][1]
+        tmpl.children().eq(0).children().eq(1).children().eq(1).children().eq(2).children().eq(1).children().eq(1).find('input[name="price"]').length.should.be.eq(1);
+
+        done();
+      });
+    });
   });
 
 });


### PR DESCRIPTION
When using nested arrays it is not possible to have a condition that targets specific elements in the nested array. ArrayIndex only gives you access to the inner most array index. I raised this as issue https://github.com/json-schema-form/angular-schema-form/issues/596 

Therefore I have added an additional property available in conditions that is similar to arrayIndex called **arrayIndices** which is an array of the array indices. For a 3 deep nested array it equates to the AngularJS:

`arrayIndices = [$parent.$parent.$index, $parent.$index, $index]`

It can be used in a condition like this:

` "condition": "model.grandParent[arrayIndices[0]].parent[arrayIndices[1]].child[arrayIndices[2]].age > 18`
  
I have not altered arrayIndex to ensure it continues to work as is.

I have implemented this in the src/services/decorators.js by filtering the integers out of the **form.key** array.

I have also implemented it in the src/services/builder.js . Here I filter the empty strings out of the **args.form.key** array to establish the array depth, then used this to build the array of [$index][$parent.$parent.$index][$parent.$parent.$parent.$parent.$index]...

I have added a test to \tests\directives\schema-form-tests.js that uses the builder.js version. The test uses a 3 deep array of the structure array.object.array.object.object.array.object (so arrays in arrays, and objects in objects). The test form contains conditions targeting elements all levels of the structure.

I have checked my code conforms to the Google code style (jscs) as suggested in the contribution guidelines.

I have not yet added anything to the docs as I wanted to hear any feedback and see if people approve the term arrayIndices (as appose to arrayIndexes or another term). If this change is approved I'm happy to add to the docs.

Please let me know if you have any questions or feedback. Thanks.

 