### PR TITLE
Correct typos in documentation examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -774,7 +774,7 @@ function FormCtrl($scope) {
         "title": "Eligible for awesome things"
       },
       "code": {
-        "type":"string"
+        "type":"string",
         "title": "The Code"
       }
     }
@@ -817,7 +817,7 @@ function FormCtrl($scope) {
               "title": "Eligible for awesome things"
             },
             "code": {
-              "type":"string"
+              "type":"string",
               "title": "The Code"
             }
           }
@@ -1599,7 +1599,7 @@ function FormCtrl($scope) {
         "title": "Eligible for awesome things"
       },
       "code": {
-        "type":"string"
+        "type":"string",
         "title": "The Code"
       }
     }
@@ -1645,7 +1645,7 @@ function FormCtrl($scope) {
               "title": "Eligible for awesome things"
             },
             "code": {
-              "type":"string"
+              "type":"string",
               "title": "The Code"
             }
           }


### PR DESCRIPTION
Missing commas in several examples.