### PR TITLE
Add check for schema property to prevent form generation failures whe…

### DIFF
--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -384,8 +384,14 @@ angular.module('schemaForm').provider('schemaForm',
 
         // Special case: checkbox
         // Since have to ternary state we need a default
-        if (obj.type === 'checkbox' && angular.isUndefined(obj.schema['default'])) {
-          obj.schema['default'] = false;
+        if (obj.type === 'checkbox') {
+          // Check for schema property, as the checkbox may be part of the explicitly defined form
+          if (angular.isUndefined(obj.schema)) {
+            obj.schema = { default: false };
+          }
+          else if (angular.isUndefined(obj.schema['default'])) {
+            obj.schema['default'] = false;
+          }
         }
 
         // Special case: template type with tempplateUrl that's needs to be loaded before rendering

--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -386,10 +386,10 @@ angular.module('schemaForm').provider('schemaForm',
         // Since have to ternary state we need a default
         if (obj.type === 'checkbox') {
           // Check for schema property, as the checkbox may be part of the explicitly defined form
-          if (angular.isUndefined(obj.schema)) {
+          if (obj.schema === undefined) {
             obj.schema = { default: false };
           }
-          else if (angular.isUndefined(obj.schema['default'])) {
+          else if (obj.schema['default'] === undefined) {
             obj.schema['default'] = false;
           }
         }


### PR DESCRIPTION
…n a checkbox is explicitly defined by a developer (and therefore does not have a schema property)

Fixes: https://github.com/json-schema-form/angular-schema-form/issues/558
