### PR TITLE
Proposed fix for issue 590

### DIFF
--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -133,7 +133,7 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
       var items = args.fieldFrag.querySelector('[schema-form-array-items]');
       if (items) {
         state = angular.copy(args.state);
-        state.keyRedaction = state.keyRedaction || 0;
+        state.keyRedaction = 0;
         state.keyRedaction += args.form.key.length + 1;
 
         // Special case, an array with just one item in it that is not an object.


### PR DESCRIPTION
#### Description

Fixes issue 590, which describes a bug that appears when you're using nested arrays. 
The described bug causes element values in the second nesting level to appear as [Object object].

#### Fixes Related issues
https://github.com/json-schema-form/angular-schema-form-bootstrap/issues/9

#### Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [ ] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead

Reset keyRedaction variable so that the parent's keyRedaction will not be carried onto its children which used to cause the key to be an empty array inside the ngModel builder.