### PR TITLE
Add support for templates with leading whitespaces

### DIFF
--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -11,9 +11,19 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
   };
   var formId = 0;
 
+  if (!("firstElementChild" in document.createDocumentFragment())) {
+    Object.defineProperty(DocumentFragment.prototype, "firstElementChild", {
+      get: function () {
+        for (var nodes = this.childNodes, n, i = 0, l = nodes.length; i < l; ++i)
+          if (n = nodes[i], 1 === n.nodeType) return n;
+        return null;
+      }
+    });
+  }
+
   var builders = {
     sfField: function(args) {
-      args.fieldFrag.firstChild.setAttribute('sf-field', formId);
+      args.fieldFrag.firstElementChild.setAttribute('sf-field', formId);
 
       // We use a lookup table for easy access to our form.
       args.lookup['f' + formId] = args.form;

--- a/test/directives/schema-form-test.js
+++ b/test/directives/schema-form-test.js
@@ -1902,6 +1902,35 @@ describe('directive',function(){
     });
   });
 
+  it('should use supplied template with leading whitespace in template field',function() {
+
+    inject(function($compile, $rootScope){
+      var scope = $rootScope.$new();
+      scope.person = {};
+
+      scope.schema = {
+        type: 'object',
+        properties: {
+          name: {type: 'string'}
+        }
+      };
+
+      scope.form = [
+        {
+          type: 'template',
+          template: '  <div>{{form.foo}}</div>',
+          foo: "Hello World"
+        }
+      ];
+
+      var tmpl = angular.element('<form sf-schema="schema" sf-form="form" sf-model="person"></form>');
+
+      $compile(tmpl)(scope);
+      $rootScope.$apply();
+      tmpl.html().should.be.eq('  <div sf-field="0" class="ng-scope ng-binding">Hello World</div>');
+    });
+  });
+
   it('should load template by templateUrl, with template field type',function() {
 
     inject(function($compile, $rootScope, $httpBackend){


### PR DESCRIPTION
#### Description

Schema Form templates must have the first DOM child node of type HTMLElement. This prevents us from defining template in `<script>` tags that are formatted and contain whitespace characters before first HTML element. Schema Form will fail on such templates.

This update will use the [`firstElementChild` property](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/firstElementChild) to support templates with leading whitespaces.

```html
<script type="text/ng-template" id="schf-template.html">
  <div>{{form.foo}}</div>
</script>
```

```js
scope.form = [{
    type: 'template',
    template: '  <div>{{form.foo}}</div>',
    foo: "Hello World"
}];
```

#### Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
