### PR TITLE
Fix spec: should generate default form def from a schema

### DIFF
--- a/test/services/schema-form-test.js
+++ b/test/services/schema-form-test.js
@@ -138,6 +138,9 @@ describe('schemaForm', function() {
             },
             "ngModelOptions": {},
             "type": "fieldset",
+            "key": [
+              "attributes"
+            ],
             "items": [
               {
                 "title": "Eye color",
@@ -182,6 +185,10 @@ describe('schemaForm', function() {
                 },
                 "ngModelOptions": {},
                 "type": "fieldset",
+                "key": [
+                  "attributes",
+                  "shoulders"
+                ],
                 "items": [
                   {
                     "title": "left",


### PR DESCRIPTION
#### Description

Added `key` attribute to fieldsets in a default form. This attribute was added in PR #578 

#### Fixes Related issues
- #578

#### Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead