### PR TITLE
fix package.json main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-alpha.2",
   "description": "Create complex forms from a JSON schema with angular.",
   "repository": "json-schema-form/angular-schema-form",
-  "main": "dist/schema-form.es5.js",
+  "main": "dist/schema-form.js",
   "filename": "dist/schema-form.min.js",
   "homepage": "http://schemaform.io",
   "scripts": {


### PR DESCRIPTION
When I tried to include 'angular-schema-form' (`import schemaForm from 'angular-schema-form';`) it would produce this error when trying to "compile" it with webpack:

> Module not found: Error: Cannot resolve module 'angular-schema-form/schema-form' in /scripts/src

It can be work-around like this until this is fixed here:

`import schemaForm from 'angular-schema-form/dist/schema-form';`