### PR TITLE
form '*' generate only remain keys from schema

### DIFF
--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -313,8 +313,25 @@ angular.module('schemaForm').provider('schemaForm',
       //simple case, we have a "*", just put the stdForm there
       var idx = form.indexOf('*');
       if (idx !== -1) {
-        form  = form.slice(0, idx)
-                    .concat(stdForm.form)
+        var formKeys = form.map(function(obj) {
+          if (obj.key) {
+            return obj.key;
+          }
+        }).filter(function(element) {
+          return element !== undefined;
+        });
+
+        var stdFormRemains = stdForm.form.map(function(obj) {
+          isInside = formKeys.indexOf(obj.key[0]) !== -1;
+          if (!isInside) {
+            return obj;
+          }
+        }).filter(function(element) {
+          return element !== undefined;
+        });
+
+        form = form.slice(0, idx)
+                    .concat(stdFormRemains)
                     .concat(form.slice(idx + 1));
       }
 

--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -310,9 +310,9 @@ angular.module('schemaForm').provider('schemaForm',
 
       var stdForm = service.defaults(schema, ignore, options);
 
-      //simple case, we have a "*", just put the stdForm there
-      var idx = form.indexOf('*');
-      if (idx !== -1) {
+      //simple case, we have a "...", just put the stdFormRemains there
+      var idRest = form.indexOf('...');
+      if (idRest !== -1) {
         var formKeys = form.map(function(obj) {
           if (obj.key) {
             return obj.key;
@@ -330,8 +330,16 @@ angular.module('schemaForm').provider('schemaForm',
           return element !== undefined;
         });
 
-        form = form.slice(0, idx)
+        form = form.slice(0, idRest)
                     .concat(stdFormRemains)
+                    .concat(form.slice(idRest + 1));
+      }
+
+      //simple case, we have a "*", just put the stdForm there
+      var idx = form.indexOf('*');
+      if (idx !== -1) {
+        form  = form.slice(0, idx)
+                    .concat(stdForm.form)
                     .concat(form.slice(idx + 1));
       }
 

--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -314,7 +314,9 @@ angular.module('schemaForm').provider('schemaForm',
       var idRest = form.indexOf('...');
       if (idRest !== -1) {
         var formKeys = form.map(function(obj) {
-          if (obj.key) {
+          if (typeof obj === 'string'){
+            return obj;
+          } else if (obj.key) {
             return obj.key;
           }
         }).filter(function(element) {


### PR DESCRIPTION
#### Description

Add your description here
#### Fixes Related issues
- add related
- issues here
#### Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [ ] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
- it is now possible to add custom keys to the form and add '...' for the remaining keys
