### PR TITLE
Add support for function instead of string in name/description field …

### DIFF
--- a/src/services/schema-form.js
+++ b/src/services/schema-form.js
@@ -70,12 +70,26 @@ angular.module('schemaForm').provider('schemaForm',
     var f = options.global && options.global.formDefaults ?
             angular.copy(options.global.formDefaults) : {};
     if (options.global && options.global.supressPropertyTitles === true) {
-      f.title = schema.title;
+      if (typeof schema.title === 'function') {
+        f.title = schema.title();
+      } else {
+        f.title = schema.title;
+      }
     } else {
-      f.title = schema.title || name;
+      if (typeof schema.title === 'function') {
+        f.title = schema.title() || name;
+      } else {
+        f.title = schema.title || name;
+      }
     }
 
-    if (schema.description) { f.description = schema.description; }
+    if (schema.description) {
+      if (typeof f.description === 'function') {
+        f.description = schema.description();
+      } else {
+        f.description = schema.description;
+      }
+    }
     if (options.required === true || schema.required === true) { f.required = true; }
     if (schema.maxLength) { f.maxlength = schema.maxLength; }
     if (schema.minLength) { f.minlength = schema.minLength; }


### PR DESCRIPTION
#### Description

Add support for function instead of string in schema object.

You can now use 

```
let schema = {
        type: "object",
        properties: {
                name: {
                    type: "string",
                    minLength: 2,
                    title: () => $filter('translate')("Name"),
                    description: () => $filter('translate')("Description")
                },
                title: {
                    type: "string",
                    enum: ['dr','jr','sir','mrs','mr','NaN','dj']
                }
            };
```
#### Fixes Related issues
#754
#### Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [ ] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR
