### PR TITLE
[Issue 769]: Fix retrieval of the correct Object during $destroy on elements within an Array

### DIFF
--- a/src/directives/field.js
+++ b/src/directives/field.js
@@ -221,7 +221,17 @@ angular.module('schemaForm').directive('sfField',
                     // Get the object that has the property we wan't to clear.
                     var obj = scope.model;
                     if (form.key.length > 1) {
-                      obj = sfSelect(form.key.slice(0, form.key.length - 1), obj);
+
+                      // If form.key is an element of an Array, update it with the ArrayIndex so that sfSelect
+                      // works correctly
+                      if (form.key.indexOf('') !== -1) {
+                        var updatedFormKey = form.key.map(function(v) {
+                          return v === '' ? scope.$index : v;
+                        });
+                        obj = sfSelect(updatedFormKey.slice(0, form.key.length - 1), obj);
+                      } else {
+                        obj = sfSelect(form.key.slice(0, form.key.length - 1), obj);
+                      }
                     }
 
                     // We can get undefined here if the form hasn't been filled out entirely


### PR DESCRIPTION
#### Description

During a $destroy (e.g. when conditions evaluate to false), `form.key` is used to access the appropriate part of the Model in order to apply the DestroyStrategy.

This does not work for Elements within an Array, because `form.key` looks like this:
`['array', '', 'property']`
In other words, it does not have a reference to the ArrayIndex of the Element (within which contains the property to be destroyed).

My fix was to make a copy of the `form.key` (in order to avoid breaking anything else that depends on its original format), and then update it so that it looks like this:
`['array', '5', 'property']`
Where `'5'` here is just an example of the ArrayIndex.

This "updated" `form.key` is then used in the `sfSelect` to correctly access the appropriate part of the Model to be destroyed.
#### Fixes Related issues
- https://github.com/json-schema-form/angular-schema-form/issues/769
#### Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [ ] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
