### PR TITLE
adding raw template to decorator

### DIFF
--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -277,8 +277,8 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
        */
       build: function(form, decorator, slots, lookup) {
         return build(form, decorator, function(form, field) {
-          if (form.type === 'template') {
-            return form.template;
+          if (field.type === 'template') {
+            return field.template;
           }
           return $templateCache.get(field.template);
         }, slots, undefined, undefined, lookup);

--- a/test/services/decorators-test.js
+++ b/test/services/decorators-test.js
@@ -26,4 +26,28 @@ describe('schemaFormDecorators', function() {
       });
     });
   });
+  describe('#createDecoratorWithRawTemplate', function() {
+    it('should enable you to create new decorator directives',function(){
+      module(function(schemaFormDecoratorsProvider){
+        schemaFormDecoratorsProvider.defineDecorator('foobar',{
+          'foo': {template: '<div class="yes">YES</div>', replace: true, type: 'template'}
+        },[angular.noop]);
+      });
+
+      inject(function($rootScope,$compile){
+
+        //Since our directive does a replace we need a wrapper to actually check the content.
+        var templateWithWrap = angular.element('<div id="wrap"><foobar form="{ type: \'foo\'}"></foobar></div>');
+        var template         = templateWithWrap.children().eq(0);
+
+        $compile(template)($rootScope);
+        $rootScope.$apply();
+        templateWithWrap.children().length.should.equal(1);
+        templateWithWrap.children().is('foobar').should.be.true;
+        templateWithWrap.children().eq(0).children().length.should.equal(1);
+        templateWithWrap.children().eq(0).children().is('div').should.be.true;
+        templateWithWrap.children().eq(0).children().hasClass('yes').should.be.true;
+      });
+    });
+  });
 });


### PR DESCRIPTION
####  Description

Currently setting the template for a custom decorator requires using the template cache, and you cannot pass in a raw template string. There is some code inside the decorator provider to support it, but it is not exposed, as it does not work.

When manually setting the decorator to have type equals to template, the builder cannot find the raw template. This is because it is looking for the 'template' field on the wrong variable, checking the form instead of the 'field'.

To test out using a raw template, you can try
```
schemaFormDecoratorsProvider.decorator('bootstrapDecorator')['myCustomDecorator'].type = 'template';
```




####  Fixes Related issues
- This doesn't expose raw templates to the decorator helper methods, however, it does get rid of the bugs so it can be exposed in the future.

####  Checklist
- [Y] I have read and understand the CONTRIBUTIONS.md file
- [Y] I have searched for and linked related issues
- [Y ] I have created test cases to ensure quick resolution of the PR is easier
- [Y] I am NOT targeting main branch
- [Y] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead

