### PR TITLE
changed schema-form.js to angular-schema-form.js in builder examples

### DIFF
--- a/examples/builder.html
+++ b/examples/builder.html
@@ -10,7 +10,7 @@
 
     <script src="../bower_components/angular/angular.js" charset="utf-8"></script>
     <script src="../bower_components/tv4/tv4.js" charset="utf-8"></script>
-    <script src="../dist/schema-form.js" charset="utf-8"></script>
+    <script src="../dist/angular-schema-form.js" charset="utf-8"></script>
     <script src="../bower_components/objectpath/lib/ObjectPath.js"></script>
 
     <script type="text/javascript">

--- a/examples/builder2.html
+++ b/examples/builder2.html
@@ -10,7 +10,7 @@
 
     <script src="../bower_components/angular/angular.js" charset="utf-8"></script>
     <script src="../bower_components/tv4/tv4.js" charset="utf-8"></script>
-    <script src="../dist/schema-form.js" charset="utf-8"></script>
+    <script src="../dist/angular-schema-form.js" charset="utf-8"></script>
     <script src="../bower_components/objectpath/lib/ObjectPath.js"></script>
 
     <script type="text/javascript">


### PR DESCRIPTION
This is a very small update to the examples.
I believe the angular-schema-form.js filename was changed.
