### PR TITLE
Fix error in extend doc (sfBuildersProvider -> sfBuilderProvider)

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -269,19 +269,19 @@ both from the provider and the service on the property `builders`. There is also
 builders, when in doubt use those.
 
 ```js
-angular.module('myMod').config(function(sfBuildersProvider) {
+angular.module('myMod').config(function(sfBuilderProvider) {
 
   // Standard builders
-  sfBuildersProvider.stdBuilders;
+  sfBuilderProvider.stdBuilders;
 
   // All builders
-  sfBuildersProvider.builders.sfField;
-  sfBuildersProvider.builders.condition;
-  sfBuildersProvider.builders.ngModel;
-  sfBuildersProvider.builders.ngModelOptions;
-  sfBuildersProvider.builders.simpleTransclusion;
-  sfBuildersProvider.builders.transclusion;
-  sfBuildersProvider.builders.array;
+  sfBuilderProvider.builders.sfField;
+  sfBuilderProvider.builders.condition;
+  sfBuilderProvider.builders.ngModel;
+  sfBuilderProvider.builders.ngModelOptions;
+  sfBuilderProvider.builders.simpleTransclusion;
+  sfBuilderProvider.builders.transclusion;
+  sfBuilderProvider.builders.array;
 
 });
 ```


### PR DESCRIPTION
Convert non-existing sfBuildersProvider to sfBuilderProvider

####  Description

Add your description here

####  Fixes Related issues
- add related
- issues here

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
