### PR TITLE
add regression tests for #900

### DIFF
--- a/src/services/schema-form.provider.spec.js
+++ b/src/services/schema-form.provider.spec.js
@@ -617,8 +617,8 @@ describe('schema-form.provider.js', function() {
         var nameKey = objectPropertyKeys.items[0].key;
         var ageKey = objectPropertyKeys.items[1].key;
 
-        nameKey.pop().should.eq("name");
-        ageKey.pop().should.eq("age");
+        nameKey.join('.').should.eq("peopleLivingWithYou.dependentChildren..name");
+        ageKey.join('.').should.eq("peopleLivingWithYou.dependentChildren..age");
       });
     });
   });

--- a/src/services/schema-form.provider.spec.js
+++ b/src/services/schema-form.provider.spec.js
@@ -568,39 +568,39 @@ describe('schema-form.provider.js', function() {
       });
     });
 
-    it('regression test for merging schema that defines an array of objects #900', function() {
-      inject(function(schemaForm) {
-
-        var arrayObjectSchema = {
+    var arrayObjectSchema = {
+      type: "object",
+      properties: {
+        peopleLivingWithYou: {
           type: "object",
           properties: {
-            peopleLivingWithYou: {
-              type: "object",
-              properties: {
-                dependentChildren: {
-                  type: "array",
-                  minItems: 1,
-                  items: {
-                    type: "object",
-                    properties: {
-                      name: {
-                        title: "Name",
-                        type: "string"
-                      },
-                      age: {
-                        title: "Age",
-                        type: "integer"
-                      }
-                    },
-                    required: ["name"]
+            dependentChildren: {
+              type: "array",
+              minItems: 1,
+              items: {
+                type: "object",
+                properties: {
+                  name: {
+                    title: "Name",
+                    type: "string"
+                  },
+                  age: {
+                    title: "Age",
+                    type: "integer"
                   }
-                }
-              },
-              required: ["dependentChildren"]
+                },
+                required: ["name"]
+              }
             }
           },
-          required: ["peopleLivingWithYou"]
-        };
+          required: ["dependentChildren"]
+        }
+      },
+      required: ["peopleLivingWithYou"]
+    };
+
+    it('merge a schema that defines an array of objects with a form inside a section #900', function() {
+      inject(function(schemaForm) {
 
         var formInsideSection = [{
           type: 'section',
@@ -614,6 +614,26 @@ describe('schema-form.provider.js', function() {
 
         var merged = schemaForm.merge(arrayObjectSchema, formInsideSection);
         var objectPropertyKeys = merged[0].items[0].items[0];
+        var nameKey = objectPropertyKeys.items[0].key;
+        var ageKey = objectPropertyKeys.items[1].key;
+
+        nameKey.join('.').should.eq("peopleLivingWithYou.dependentChildren..name");
+        ageKey.join('.').should.eq("peopleLivingWithYou.dependentChildren..age");
+      });
+    });
+
+    it('merge a schema that defines an array of objects with a form without a section #900', function() {
+      inject(function(schemaForm) {
+
+        var formWithoutSection = [{
+          key: 'peopleLivingWithYou.dependentChildren',
+          add: "Add Child",
+          title: 'Dependent children details',
+          validationMessage: 'Complete all required fields for at least one child'
+        }];
+
+        var merged = schemaForm.merge(arrayObjectSchema, formWithoutSection);
+        var objectPropertyKeys = merged[0].items[0];
         var nameKey = objectPropertyKeys.items[0].key;
         var ageKey = objectPropertyKeys.items[1].key;
 

--- a/src/services/schema-form.provider.spec.js
+++ b/src/services/schema-form.provider.spec.js
@@ -567,5 +567,59 @@ describe('schema-form.provider.js', function() {
 
       });
     });
+
+    it('regression test for merging schema that defines an array of objects #900', function() {
+      inject(function(schemaForm) {
+
+        var arrayObjectSchema = {
+          type: "object",
+          properties: {
+            peopleLivingWithYou: {
+              type: "object",
+              properties: {
+                dependentChildren: {
+                  type: "array",
+                  minItems: 1,
+                  items: {
+                    type: "object",
+                    properties: {
+                      name: {
+                        title: "Name",
+                        type: "string"
+                      },
+                      age: {
+                        title: "Age",
+                        type: "integer"
+                      }
+                    },
+                    required: ["name"]
+                  }
+                }
+              },
+              required: ["dependentChildren"]
+            }
+          },
+          required: ["peopleLivingWithYou"]
+        };
+
+        var formInsideSection = [{
+          type: 'section',
+          items: [{
+            key: 'peopleLivingWithYou.dependentChildren',
+            add: "Add Child",
+            title: 'Dependent children details',
+            validationMessage: 'Complete all required fields for at least one child'
+          }]
+        }];
+
+        var merged = schemaForm.merge(arrayObjectSchema, formInsideSection);
+        var objectPropertyKeys = merged[0].items[0].items[0];
+        var nameKey = objectPropertyKeys.items[0].key;
+        var ageKey = objectPropertyKeys.items[1].key;
+
+        nameKey.pop().should.eq("name");
+        ageKey.pop().should.eq("age");
+      });
+    });
   });
 });


### PR DESCRIPTION
####  Description
This PR adds regression tests for #900. Curiously, the test does _not_ reproduce the issue demonstrated by [the Plunker example](https://plnkr.co/edit/H1ZEhzr5J9yRNouR5vVN?p=preview) even though the schema and form definitions are identical in both.

In the Plunker demo, the keys are:
- name: `["", 0, "peopleLivingWithYou", "dependentChildren", 0]`
- age: `["", 0, "peopleLivingWithYou", "dependentChildren", 0]`

Whereas in the unit tests, the keys are:
- name: `["peopleLivingWithYou", "dependentChildren", "", "name"]`
- age: `["peopleLivingWithYou", "dependentChildren", "", "age"]`

In my particular case, the only thing I really care about is that the last element of the key array is the property name, so if I could get the same behaviour in the Plunker demo (and my app), I'd be satisfied.

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
