### PR TITLE
replace `angular.uppercase` with `String.prototype.toUpperCase()`

### DIFF
--- a/src/services/schema-form-decorators.provider.js
+++ b/src/services/schema-form-decorators.provider.js
@@ -380,7 +380,7 @@ export default function($compileProvider, sfPathProvider) {
 
   let createManualDirective = function(type, templateUrl, transclude) {
     transclude = angular.isDefined(transclude) ? transclude : false;
-    $compileProvider.directive('sf' + angular.uppercase(type[0]) + type.substr(1), function() {
+    $compileProvider.directive('sf' + type[0].toUpperCase() + type.substr(1), function() {
       return {
         restrict: 'EAC',
         scope: true,


### PR DESCRIPTION
####  Description

This PR replaces the use of `angular.uppercase` with `String.prototype.toUpperCase()`, as AngularJS has [removed their helper functions](https://github.com/angular/angular.js/commit/1daa4f2231a89ee88345689f001805ffffa9e7de).

####  Fixes Related issues
- Fixes #970

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [ ] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
