### PR TITLE
replace `angular.uppercase` with `String.prototype.toUpperCase()` (master/v0.8.13)

### DIFF
--- a/src/services/decorators.js
+++ b/src/services/decorators.js
@@ -318,7 +318,7 @@ angular.module('schemaForm').provider('schemaFormDecorators',
 
   var createManualDirective = function(type, templateUrl, transclude) {
     transclude = angular.isDefined(transclude) ? transclude : false;
-    $compileProvider.directive('sf' + angular.uppercase(type[0]) + type.substr(1), function() {
+    $compileProvider.directive('sf' + type[0].toUpperCase() + type.substr(1), function() {
       return {
         restrict: 'EAC',
         scope: true,


### PR DESCRIPTION
####  Description

Note that I also created a [PR for the develop branch](https://github.com/json-schema-form/angular-schema-form/pull/976) (v1.0), so please do not consider this to be a duplicate (although the fix is the same).

This PR replaces the use of `angular.uppercase` with `String.prototype.toUpperCase()`, as AngularJS has [removed their helper functions](https://github.com/angular/angular.js/commit/1daa4f2231a89ee88345689f001805ffffa9e7de).

This PR is intentionally targeted for the master branch, despite the instructions in the contribution guidelines. This fix is necessary for production systems currently using the latest stable version of AngularJS. Since v0.8.13 is still listed as the primary version on NPM, and since v1.0 has been in development for quite some time, it seems reasonable that this fix should be released for v0.8.13 (or v0.8.14, as the case may be) right away.

####  Fixes Related issues
- Fixes #970

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [ ] I have created test cases to ensure quick resolution of the PR is easier
- [ ] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
