### PR TITLE
Fix Karma Unit Tests (support/0.x)

### DIFF
--- a/test/directives/schema-form-test.js
+++ b/test/directives/schema-form-test.js
@@ -2144,10 +2144,10 @@ describe('directive',function(){
       ngModelCtrl.$valid = true;
       ngModelCtrl.$pristine = false;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-success').should.be.true;
+      tmpl.children().eq(0).hasClass('has-success').should.be.true;
       scope.form[0].disableSuccessState = true;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-success').should.be.false;
+      tmpl.children().eq(0).hasClass('has-success').should.be.false;
     });
   });
 
@@ -2194,10 +2194,10 @@ describe('directive',function(){
       ngModelCtrl.$invalid = true;
       ngModelCtrl.$pristine = false;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-error').should.be.true;
+      tmpl.children().eq(0).hasClass('has-error').should.be.true;
       scope.form[0].disableErrorState = true;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-error').should.be.false;
+      tmpl.children().eq(0).hasClass('has-error').should.be.false;
     });
   });
 
@@ -2242,10 +2242,10 @@ describe('directive',function(){
       ngModelCtrl.$valid = true;
       ngModelCtrl.$pristine = false;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-success').should.be.true;
+      tmpl.children().eq(0).hasClass('has-success').should.be.true;
       scope.form[0].disableSuccessState = true;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-success').should.be.false;
+      tmpl.children().eq(0).hasClass('has-success').should.be.false;
     });
   });
 
@@ -2292,10 +2292,10 @@ describe('directive',function(){
       ngModelCtrl.$invalid = true;
       ngModelCtrl.$pristine = false;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-error').should.be.true;
+      tmpl.children().eq(0).hasClass('has-error').should.be.true;
       scope.form[0].disableErrorState = true;
       $rootScope.$apply();
-      tmpl.children().eq(0).children().eq(0).hasClass('has-error').should.be.false;
+      tmpl.children().eq(0).hasClass('has-error').should.be.false;
     });
   });
 

--- a/test/directives/sf-messages-test.js
+++ b/test/directives/sf-messages-test.js
@@ -36,7 +36,6 @@ describe('directive',function() {
 
       $compile(tmpl)(scope);
       $rootScope.$apply();
-      console.log(tmpl.children().find('div.help-block')[0]);
       tmpl.children().find('div.help-block').text().should.equal('foobar');
 
       setTimeout(function() {


### PR DESCRIPTION
####  Description

This PR fixes the Karma unit tests for the `support/0.x` branch. Specifically, the checks for the `has-error` and `has-success` classes were targeting the wrong DOM nodes.

####  Checklist
- [x] I have read and understand the CONTRIBUTIONS.md file
- [x] I have searched for and linked related issues
- [x] I have created test cases to ensure quick resolution of the PR is easier
- [x] I am NOT targeting main branch
- [x] I did NOT include the dist folder in my PR

@json-schema-form/angular-schema-form-lead
